### PR TITLE
Fix build errors and warnings

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,6 +4,9 @@
  * See: https://www.gatsbyjs.org/docs/node-apis/
  */
 
+// Increase the maximum number of event listeners to prevent memory leak warnings
+require('events').EventEmitter.defaultMaxListeners = 20;
+
 const path = require('path');
 const _ = require('lodash');
 

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   "license": "MIT",
   "browserslist": "> 0.25%, not dead",
   "scripts": {
-    "build": "gatsby build",
-    "develop": "gatsby develop",
+    "build": "NODE_OPTIONS='--openssl-legacy-provider --max-old-space-size=4096' gatsby build",
+    "develop": "NODE_OPTIONS='--openssl-legacy-provider --max-old-space-size=4096' gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
-    "serve": "gatsby serve",
+    "serve": "NODE_OPTIONS='--openssl-legacy-provider' gatsby serve",
     "clean": "gatsby clean",
     "prepare": "husky install",
     "lint-staged": "lint-staged"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3417,9 +3417,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001196, caniuse-lite@^1.0.30001219:
-  version "1.0.30001282"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz"
-  integrity sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==
+  version "1.0.30001727"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz"
+  integrity sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==
 
 caw@^2.0.0, caw@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Fix Gatsby build errors related to Node.js 17+ and memory warnings.

The `error:0308010C:digital envelope routines::unsupported` error occurs because Node.js 17+ uses OpenSSL 3.0, which removed support for legacy hash algorithms that Gatsby v3's webpack version depends on. This PR adds the `--openssl-legacy-provider` flag to Gatsby scripts to resolve this. The `MaxListenersExceededWarning` is also addressed by increasing `EventEmitter.defaultMaxListeners` in `gatsby-node.js`, and the `caniuse-lite` database is updated.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-1732cebf-3d90-4653-af84-2c7ef141020f) · [Cursor](https://cursor.com/background-agent?bcId=bc-1732cebf-3d90-4653-af84-2c7ef141020f)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)